### PR TITLE
add runAfterEmit option to choose execution stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ var config = {
       saveAs: path.join(__dirname, 'build', 'subresource-integrity-mapping.json'),
       write: true,
       writeDirectMapping: true,
-      resultsKey: '__RESULTS_SRIS'
+      resultsKey: '__RESULTS_SRIS',
+      runAfterEmit: true
     })
  ]
 };
@@ -84,6 +85,10 @@ var config = {
   Default: `true`
 - `resultsKey`: Where to save the results to in webpack's `compilation` object.
   Default: `__RESULTS_SRIS`
+- `runAfterEmit`: Boolean option, whether to calculate hashes during or after
+  emit stage. If HTMLWebpackPlugin is supposed to pick up the hashes (during
+  emit stage), set to false and run this plugin first.
+  Default: `true`
 
 ## License
 MIT.

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ SriStatsWebpackPlugin.prototype.apply = function(compiler) {
     });
   });
 
-  compiler.plugin('after-emit', function(compilation, callback) {
+  compiler.plugin('emit', function(compilation, callback) {
     var stats = new CustomStats(compilation);
 
     stats.addCustomStat(customStatsKey, sris);

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var DEFAULT_PARAMS = {
   saveAs: path.join(process.cwd(), 'build', 'subresource-integrity-map.json'),
   write: false,
   writeDirectMapping: true,
-  resultsKey: '__RESULTS_SRIS'
+  resultsKey: '__RESULTS_SRIS',
+  runAfterEmit: 'true'
 };
 
 function SriStatsWebpackPlugin(options) {
@@ -33,6 +34,7 @@ function SriStatsWebpackPlugin(options) {
   this._write = ((params.write === undefined) ? DEFAULT_PARAMS.write : params.write);
   this._writeDirectMapping = ((params.writeDirectMapping === undefined) ? DEFAULT_PARAMS.writeDirectMapping : params.writeDirectMapping);
   this._resultsKey = params.resultsKey || DEFAULT_PARAMS.resultsKey;
+  this._runAfterEmit = ((params.runAfterEmit === undefined) ? DEFAULT_PARAMS.runAfterEmit : params.runAfterEmit);
 }
 
 SriStatsWebpackPlugin.prototype.getAlgorithm = function getAlgorithm() {
@@ -48,6 +50,7 @@ SriStatsWebpackPlugin.prototype.apply = function(compiler) {
   var writeEnabled = this._write;
   var writeDirectMapping = this._writeDirectMapping;
   var resultsKey = this._resultsKey;
+  var stage = this._runAfterEmit ? 'after-emit' : 'emit';
   var directMapping = {};
   var sris = {};
 
@@ -72,7 +75,7 @@ SriStatsWebpackPlugin.prototype.apply = function(compiler) {
     });
   });
 
-  compiler.plugin('emit', function(compilation, callback) {
+  compiler.plugin(stage, function(compilation, callback) {
     var stats = new CustomStats(compilation);
 
     stats.addCustomStat(customStatsKey, sris);


### PR DESCRIPTION
if set to false, hashes are calculated during emit stage and can be picked up by HTMLWebpackPlugin, which is executed during emit stage, too
